### PR TITLE
Fix for report generation in multi-module maven projects

### DIFF
--- a/scct/src/main/scala/reaktor/scct/ScctInstrumentPlugin.scala
+++ b/scct/src/main/scala/reaktor/scct/ScctInstrumentPlugin.scala
@@ -183,7 +183,6 @@ class ScctTransformComponent(val global: Global) extends PluginComponent with Ty
 
     private def coverageCall(tree: Tree) = {
       val id = newId
-      println("MMMMMMMMMM instrumenting: " + currentOwner)
       data = CoveredBlock(id, createName(currentOwner, tree), minOffset(tree), false) :: data
       fitIntoTree(tree, rawCoverageCall(id))
     }

--- a/scct/src/main/scala/reaktor/scct/ScctInstrumentPlugin.scala
+++ b/scct/src/main/scala/reaktor/scct/ScctInstrumentPlugin.scala
@@ -10,7 +10,7 @@ class ScctInstrumentPlugin(val global: Global) extends Plugin {
   val name = "scct"
   val description = "Scala code coverage instrumentation plugin."
   val runsAfter = List("refchecks")
-  val components = List(new ScctTransformComponent(global))
+  val components = if (global.settings.outdir.value.endsWith("test-classes")) List() else List(new ScctTransformComponent(global))
 }
 
 class ScctTransformComponent(val global: Global) extends PluginComponent with TypingTransformers with Transform {
@@ -183,6 +183,7 @@ class ScctTransformComponent(val global: Global) extends PluginComponent with Ty
 
     private def coverageCall(tree: Tree) = {
       val id = newId
+      println("MMMMMMMMMM instrumenting: " + currentOwner)
       data = CoveredBlock(id, createName(currentOwner, tree), minOffset(tree), false) :: data
       fitIntoTree(tree, rawCoverageCall(id))
     }

--- a/scct/src/main/scala/reaktor/scct/report/HtmlReporter.scala
+++ b/scct/src/main/scala/reaktor/scct/report/HtmlReporter.scala
@@ -1,13 +1,29 @@
 package reaktor.scct.report
 
-import java.io.File
-import io.Source
-import xml.{Text, Node, NodeSeq}
 import reaktor.scct._
 
 object HtmlReporter {
-  def report(blocks: List[CoveredBlock], env: Env) =
-    new HtmlReporter(new CoverageData(blocks), new HtmlReportWriter(env.reportDir), env).report
+
+
+  def report(blocks: List[CoveredBlock], env: Env)  = {
+
+    def fixRelativePathForMaven(sourceFile: String) : String = {
+      val prefix: String = env.projectId + "/"
+
+      if (sourceFile.startsWith(prefix)) sourceFile.substring(prefix.length, sourceFile.length)
+      else sourceFile
+    }
+
+    def fixRelativePathInCoveredBlockForMaven(block:CoveredBlock): CoveredBlock = {
+      val name: Name = block.name
+      val nameWithFixedRelativePath: Name = Name(fixRelativePathForMaven(name.sourceFile), name.classType, name.packageName, name.className)
+      val blockWithFixedRelativePath: CoveredBlock =  new CoveredBlock(block.id, nameWithFixedRelativePath, block.offset, block.placeHolder)
+      blockWithFixedRelativePath.count = block.count
+      blockWithFixedRelativePath
+    }
+
+    new HtmlReporter(new CoverageData(blocks.map(fixRelativePathInCoveredBlockForMaven)), new HtmlReportWriter(env.reportDir), env).report
+  }
 }
 
 class HtmlReporter(data: CoverageData, writer: HtmlReportWriter, env: Env) extends HtmlHelper {
@@ -36,26 +52,26 @@ class HtmlReporter(data: CoverageData, writer: HtmlReportWriter, env: Env) exten
     val html =
       <div class="content">
         <div class="pkgRow header">
-          <a href={files.summary}>Summary { format(data.percentage) }</a>
-        </div>
-        {
-          for ((pkg, packageData) <- data.forPackages) yield {
-            <div class="pkgRow pkgLink">
-              <a href={packageReportFileName(pkg)}>
-                { pkg }&nbsp;{ format(packageData.percentage) }
+          <a href={files.summary}>Summary
+            {format(data.percentage)}
+          </a>
+        </div>{for ((pkg, packageData) <- data.forPackages) yield {
+        <div class="pkgRow pkgLink">
+          <a href={packageReportFileName(pkg)}>
+            {pkg}&nbsp;{format(packageData.percentage)}
+          </a>
+        </div> ++
+          <div class="pkgRow pkgContent">
+            {for ((clazz, classData) <- packageData.forClasses) yield
+            <div class="pkgRow">
+              <a href={classHref(clazz)}>
+                <span class="className">
+                  {classNameHeader(clazz)}
+                </span> &nbsp;{format(classData.percentage)}
               </a>
-            </div> ++
-            <div class="pkgRow pkgContent">
-              { for ((clazz, classData) <- packageData.forClasses) yield
-                  <div class="pkgRow">
-                    <a href={ classHref(clazz) }>
-                      <span class="className">{ classNameHeader(clazz) }</span>&nbsp;{ format(classData.percentage) }
-                    </a>
-                  </div>
-              }
-            </div>
-          }
-        }
+            </div>}
+          </div>
+      }}
       </div>
     writer.write(files.packages, html)
   }
@@ -71,15 +87,19 @@ class HtmlReporter(data: CoverageData, writer: HtmlReportWriter, env: Env) exten
   def resources {
     val rs = List("class.png", "object.png", "package.png", "trait.png", "filter_box_left.png", "filter_box_right.png",
       "jquery-1.6.1.min.js", "jquery-ui-1.8.4.custom.min.js", "style.css", "main.js", "index.html")
-    rs.foreach { name =>
-      writer.write(name, IO.readResourceBytes("/html-reporting/"+name))
+    rs.foreach {
+      name =>
+        writer.write(name, IO.readResourceBytes("/html-reporting/" + name))
     }
   }
+
   def sourceFileReports {
     for ((sourceFile, sourceData) <- data.forSourceFiles) {
+
       val report = SourceFileHtmlReporter.report(sourceFile, sourceData, env)
       writer.write(sourceReportFileName(sourceFile), report)
     }
   }
+
 
 }


### PR DESCRIPTION
This patch adjusts relative paths when CoverageData is loaded by the HtmlReporter
