### PR TITLE
Performance optimizations

### DIFF
--- a/.sbtrc
+++ b/.sbtrc
@@ -1,0 +1,3 @@
+alias c=compile
+alias tc=test:compile
+alias gi=gen-idea

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ libraryDependencies <+= (scalaVersion) { v =>
 }
 
 libraryDependencies ++= Seq(
+  "it.unimi.dsi" % "fastutil" % "6.4.3" withSources,
   "junit" % "junit" % "4.7" % "test" withSources,
   "org.mockito" % "mockito-all" % "1.8.5" % "test" withSources,
   "org.specs2" % "specs2" % "1.11" % "test" cross CrossVersion.binaryMapped {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.1.0")

--- a/src/main/resources/html-reporting/style.css
+++ b/src/main/resources/html-reporting/style.css
@@ -1,6 +1,6 @@
 body { color: #444; font-family: monospace; font-size: 11px; margin: 0px;}
 h1 { color: #2F4F4F; }
-#overview { width: 300px; float: left; border-right: 1px solid #aaa; }
+#overview { min-width: 300px; max-width: 800px; float: left; border-right: 1px solid #aaa; }
 #detail { overflow: scroll; }
 #packages { overflow: scroll; }
 table { width: 99%; margin-top: 5px; }

--- a/src/main/scala/reaktor/scct/Coverage.scala
+++ b/src/main/scala/reaktor/scct/Coverage.scala
@@ -3,27 +3,21 @@ package reaktor.scct
 import report._
 
 object Coverage {
-  @uncovered var state = State.New
-  @uncovered var env: Env = _
-  @uncovered var data: Map[String, CoveredBlock] = Map[String, CoveredBlock]()
-
-  @uncovered def init() {
+  @uncovered private var state = State.New
+  @uncovered private var env: Env = _
+  @uncovered private lazy val data: Map[String, CoveredBlock] = {
     state = State.Starting
     env = new Env
-    data = readMetadata
+    val metaData = readMetadata
     env.reportHook match {
       case "system.property" => setupSystemPropertyHook
-      case _ => setupShutdownHook
+      case _                 => setupShutdownHook
     }
     state = State.Active
+    metaData
   }
 
   @uncovered def invoked(id: String) {
-    synchronized {
-      if (state == State.New) {
-        init()
-      }
-    }
     data.get(id).foreach { _.increment }
   }
 

--- a/src/main/scala/reaktor/scct/Coverage.scala
+++ b/src/main/scala/reaktor/scct/Coverage.scala
@@ -1,45 +1,56 @@
 package reaktor.scct
 
 import report._
-import it.unimi.dsi.fastutil.objects.{Object2ObjectOpenHashMap}
-import scala.collection.JavaConverters._
 
 object Coverage {
   @uncovered private var state = State.New
   @uncovered private[this] val env: Env = new Env
-  @uncovered private[this] val data: Object2ObjectOpenHashMap[String, CoveredBlock] = {
+  @uncovered private[this] val data: Map[Int, CoveredBlock] = {
     state = State.Starting
     val metaData = readMetadata
     env.reportHook match {
       case "system.property" => setupSystemPropertyHook
-      case _                 => setupShutdownHook
+      case _ => setupShutdownHook
     }
     state = State.Active
-    val data = new Object2ObjectOpenHashMap[String, CoveredBlock]()
-    data.putAll(metaData.asJava)
-    data
+    metaData
   }
 
-  @uncovered def invoked(id: String) {
-    val block = data.get(id)
-    if (block != null) block.increment
+  @uncovered private[this] val counters: Array[Int] = {
+    val size = data.keysIterator.max + 1
+    new Array[Int](size)
+  }
+
+  @uncovered def invoked(id: Int) {
+    counters(id) +=1
   }
 
   private def readMetadata = {
     try {
       val values = MetadataPickler.load(env.coverageFile)
-      Map(values.map(x => (x.id, x)) :_*)
+      Map(values.map(x => (x.id, x)): _*)
     } catch {
       case e => {
-        System.err.println("Fail: "+e)
+        System.err.println("Fail: " + e)
         e.printStackTrace
         throw e
       }
     }
   }
 
+  @uncovered
+  lazy val dataValues: List[CoveredBlock] = {
+    for {
+      (id, block) <- data
+      if block != null
+    } {
+      block.incrementBy(counters(id))
+    }
+    data.values.toList
+  }
+
   @uncovered def report = {
-    val projectData = new ProjectData(env, data.values.asScala.toList)
+    val projectData = new ProjectData(env, dataValues)
     val writer = new HtmlReportWriter(env.reportDir)
     new HtmlReporter(projectData, writer).report
     new CoberturaReporter(projectData, writer).report
@@ -55,6 +66,7 @@ object Coverage {
       }
     })
   }
+
   private def setupSystemPropertyHook {
     val prop = "scct.%s.fire.report".format(env.projectId)
     new Thread {
@@ -70,28 +82,44 @@ object Coverage {
 }
 
 @uncovered object ClassTypes {
+
   @SerialVersionUID(1L) sealed abstract class ClassType extends Serializable
+
   @SerialVersionUID(1L) case object Class extends ClassType
+
   @SerialVersionUID(1L) case object Trait extends ClassType
+
   @SerialVersionUID(1L) case object Object extends ClassType
+
   @SerialVersionUID(1L) case object Package extends ClassType
+
   @SerialVersionUID(1L) case object Root extends ClassType
+
 }
 
-@SerialVersionUID(1L) case class Name(sourceFile: String, classType: ClassTypes.ClassType, packageName: String, className: String, projectName:String) extends Ordered[Name] {
+@SerialVersionUID(1L) case class Name(sourceFile: String, classType: ClassTypes.ClassType, packageName: String, className: String, projectName: String) extends Ordered[Name] {
   def compare(other: Name) = {
     lazy val classNameDiff = className.compareTo(other.className)
     lazy val classTypeDiff = classType.toString.compareTo(other.classType.toString)
     lazy val projectNameDiff = projectName.compareTo(other.projectName)
     if (classNameDiff != 0) classNameDiff else if (classTypeDiff != 0) classTypeDiff else projectNameDiff
   }
-  override def toString = projectName+":"+packageName+"/"+className+":"+sourceFile
+
+  override def toString = projectName + ":" + packageName + "/" + className + ":" + sourceFile
 }
 
-@SerialVersionUID(1L) case class CoveredBlock(id: String, name: Name, offset: Int, placeHolder: Boolean) {
-  def this(id: String, name: Name, offset: Int)  = this(id, name, offset, false)
+@SerialVersionUID(1L) case class CoveredBlock(id: Int, name: Name, offset: Int, placeHolder: Boolean) {
+  def this(id: Int, name: Name, offset: Int) = this(id, name, offset, false)
+
   var count = 0
-  @uncovered def increment = { count = count + 1; this }
+
+  @uncovered def increment = {
+    count = count + 1; this
+  }
+
+  @uncovered def incrementBy(value: Int) = {
+    count = count + value; this
+  }
 }
 
 class uncovered extends scala.annotation.StaticAnnotation

--- a/src/main/scala/reaktor/scct/Coverage.scala
+++ b/src/main/scala/reaktor/scct/Coverage.scala
@@ -4,10 +4,9 @@ import report._
 
 object Coverage {
   @uncovered private var state = State.New
-  @uncovered private var env: Env = _
+  @uncovered private lazy val env: Env = new Env
   @uncovered private lazy val data: Map[String, CoveredBlock] = {
     state = State.Starting
-    env = new Env
     val metaData = readMetadata
     env.reportHook match {
       case "system.property" => setupSystemPropertyHook

--- a/src/main/scala/reaktor/scct/ScctInstrumentPlugin.scala
+++ b/src/main/scala/reaktor/scct/ScctInstrumentPlugin.scala
@@ -54,10 +54,15 @@ class ScctTransformComponent(val global: Global, val opts:ScctInstrumentPluginOp
 
   var debug = System.getProperty("scct.debug") == "true"
   var saveData = true
-  var counter = 0L
+  var counter = 0
   var data: List[CoveredBlock] = Nil
   lazy val coverageFile = new File(global.settings.outdir.value, "coverage.data")
-  def newId = { counter += 1; counter.toString }
+
+  def newId: Int = {
+    require(counter < Integer.MAX_VALUE)
+    counter += 1
+    counter
+  }
 
   override def newPhase(prev: scala.tools.nsc.Phase): StdPhase = new Phase(prev) {
     override def run {
@@ -222,7 +227,7 @@ class ScctTransformComponent(val global: Global, val opts:ScctInstrumentPluginOp
       localTyper.typed(atPos(orig.pos)(newTree))
     }
 
-    private def rawCoverageCall(id: String) = {
+    private def rawCoverageCall(id: Int) = {
       val fun = Select( Select( Select(Ident("reaktor"), newTermName("scct") ), newTermName("Coverage") ), newTermName("invoked") )
       Apply(fun, List(Literal(id)))
     }

--- a/src/main/scala/reaktor/scct/report/SourceLoader.scala
+++ b/src/main/scala/reaktor/scct/report/SourceLoader.scala
@@ -5,7 +5,7 @@ import io.Source
 
 class SourceLoader(baseDir:File) {
   def linesFor(sourceFile: String) = {
-    val src = Source.fromFile(new File(baseDir, sourceFile))
+    val src = Source.fromFile(new File(baseDir, sourceFile), "UTF-8")
     toLines(src)
   }
 


### PR DESCRIPTION
I'm trying to run scct on our code base (13 modules, 100K LOC) and I found some lock contention and performance problems. I optimized as much as I could with my limited understanding of how scct works.
A `test` run takes 8 minutes whereas `scct:test` takes over 150 minutes. Is it possible to replace the hash table lookup in `Coverage` with a simple array access or something? What does this lookup actually do?
