### PR TITLE
Added feature to exclude files from coverage analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ project/sbt_project_definition.iml
 lib_managed/
 target/
 self-report/
+.idea

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "reaktor"
 
 name := "scct"
 
-version := "0.2-SNAPSHOT"
+version := "0.3-SNAPSHOT"
 
 scalaVersion := "2.10.0-RC3"
 

--- a/src/main/scala/reaktor/scct/Coverage.scala
+++ b/src/main/scala/reaktor/scct/Coverage.scala
@@ -53,11 +53,19 @@ object Coverage {
   }
 
   def report = {
-    val projectData = new ProjectData(env, dataValues)
+    val filtered: List[CoveredBlock] = filteredData
+
+    val projectData = new ProjectData(env, filtered)
     val writer = new HtmlReportWriter(env.reportDir)
     new HtmlReporter(projectData, writer).report
     new CoberturaReporter(projectData, writer).report
     BinaryReporter.report(projectData, env.reportDir)
+  }
+
+  private def filteredData: List[CoveredBlock] = {
+    val excludedPaths = System.getProperty("scct.exclude.paths", "").split(",").filter(_.length > 0).map(_.r)
+    val filter = new CoverageFilter(excludedPaths)
+    filter.filter(dataValues)
   }
 
   private def setupShutdownHook {

--- a/src/main/scala/reaktor/scct/Coverage.scala
+++ b/src/main/scala/reaktor/scct/Coverage.scala
@@ -63,7 +63,7 @@ object Coverage {
   }
 
   private def filteredData: List[CoveredBlock] = {
-    val excludedPaths = System.getProperty("scct.exclude.paths", "").split(",").filter(_.length > 0).map(_.r)
+    val excludedPaths = System.getProperty("scct.excluded.paths.regex", "").split(",").filter(_.length > 0).map(_.r)
     val filter = new CoverageFilter(excludedPaths)
     filter.filter(dataValues)
   }

--- a/src/main/scala/reaktor/scct/CoverageFilter.scala
+++ b/src/main/scala/reaktor/scct/CoverageFilter.scala
@@ -1,0 +1,18 @@
+package reaktor.scct
+
+import scala.util.matching.Regex
+
+class CoverageFilter(excludePackages : Array[Regex]) {
+
+  private var debug = System.getProperty("scct.debug") == "true"
+
+  private def isIncluded(block: CoveredBlock) = {
+    val isMatched = excludePackages.filter( _.findFirstIn(block.name.sourceFile).isDefined).size > 0
+
+    if (debug && isMatched) println("scct : excluding " + block.name.sourceFile)
+
+    !isMatched
+  }
+
+  def filter(data: List[CoveredBlock]): List[CoveredBlock] = data.filter( isIncluded )
+}

--- a/src/main/scala/reaktor/scct/CoverageFilter.scala
+++ b/src/main/scala/reaktor/scct/CoverageFilter.scala
@@ -2,12 +2,12 @@ package reaktor.scct
 
 import scala.util.matching.Regex
 
-class CoverageFilter(excludePackages : Array[Regex]) {
+class CoverageFilter(excludeFiles : Array[Regex]) {
 
   private var debug = System.getProperty("scct.debug") == "true"
 
   private def isIncluded(block: CoveredBlock) = {
-    val isMatched = excludePackages.filter( _.findFirstIn(block.name.sourceFile).isDefined).size > 0
+    val isMatched = excludeFiles.filter( _.findFirstIn(block.name.sourceFile).isDefined).size > 0
 
     if (debug && isMatched) println("scct : excluding " + block.name.sourceFile)
 

--- a/src/main/scala/reaktor/scct/CoverageFilter.scala
+++ b/src/main/scala/reaktor/scct/CoverageFilter.scala
@@ -1,0 +1,13 @@
+package reaktor.scct
+
+import scala.util.matching.Regex
+
+class CoverageFilter(excludePackages : Array[Regex]) {
+
+  private def isIncluded(block: CoveredBlock) = {
+    val isMatched = excludePackages.filter( _.findFirstIn(block.name.packageName).isDefined).size > 0
+    !isMatched
+  }
+
+  def filter(data: List[CoveredBlock]): List[CoveredBlock] = data.filter( isIncluded )
+}

--- a/src/main/scala/reaktor/scct/ScctInstrumentPlugin.scala
+++ b/src/main/scala/reaktor/scct/ScctInstrumentPlugin.scala
@@ -4,7 +4,7 @@ import tools.nsc.plugins.{PluginComponent, Plugin}
 import java.io.File
 import tools.nsc.transform.{Transform, TypingTransformers}
 import tools.nsc.symtab.Flags
-import tools.nsc.{Phase, Global}
+import tools.nsc.Global
 import util.Random
 
 class ScctInstrumentPlugin(val global: Global) extends Plugin {
@@ -25,8 +25,8 @@ class ScctInstrumentPlugin(val global: Global) extends Plugin {
     }
   }
   override val optionsHelp: Option[String] = Some(
-    "  -P:scct:projectId:<name>          identify compiled classes under project <name>\n" +
-    "  -P:scct:basedir:<dir>             set the root dir of the project being compiled"
+    "  -P:scct:projectId:<name>                 identify compiled classes under project <name>\n" +
+    "  -P:scct:basedir:<dir>                    set the root dir of the project being compiled\n"
   )
 }
 
@@ -45,7 +45,6 @@ object ScctInstrumentPluginOptions {
 
 class ScctTransformComponent(val global: Global, val opts:ScctInstrumentPluginOptions) extends PluginComponent with TypingTransformers with Transform {
   import global._
-  import global.definitions._
 
   val runsAfter = List[String]("typer")
   override val runsBefore = List[String]("patmat")

--- a/src/test/scala/reaktor/scct/CoverageFilterSpec.scala
+++ b/src/test/scala/reaktor/scct/CoverageFilterSpec.scala
@@ -1,0 +1,35 @@
+package reaktor.scct
+
+import org.specs2.mutable._
+import reaktor.scct.ClassTypes.ClassType
+
+class CoverageFilterSpec extends Specification {
+
+  "empty filter does pass thru" in {
+    val data = List(block( "packageName" ))
+
+    new CoverageFilter(Array()).filter(data) mustEqual data
+  }
+
+  "non matching filter does pass thru" in {
+    val data = List(block( "packageName" ))
+    new CoverageFilter(Array("nonMatching".r)).filter(data) mustEqual data
+  }
+
+  "filter excludes matches" in {
+    val blockMatching = block( "MATCHINGPART" )
+    val blockNonMatching = block( "nonmatching" )
+
+    new CoverageFilter(Array("MATCHINGPART".r)).filter(List(blockMatching, blockNonMatching)) mustEqual List(blockNonMatching)
+  }
+
+  "multiple filters" in {
+    val blockMatching1 = block( "MATCH1.suffix" )
+    val blockMatching2 = block( "MATCH2.suffix" )
+    val blockNonMatching = block( "nonmatching" )
+
+    new CoverageFilter(Array("^MATCH1".r, "^MATCH2".r)).filter(List(blockMatching1, blockMatching2, blockNonMatching)) mustEqual List(blockNonMatching)
+  }
+
+  def block(packageName: String) = new CoveredBlock("c1", 1, Name("file1", ClassTypes.Class, packageName, "className", "projectName"), 1, false)
+}

--- a/src/test/scala/reaktor/scct/ScctInstrumentPluginSpec.scala
+++ b/src/test/scala/reaktor/scct/ScctInstrumentPluginSpec.scala
@@ -30,9 +30,10 @@ class ScctInstrumentPluginSpec extends Specification with Mockito {
       sut.options.baseDir.getName must not be empty
     }
     "be settable" in {
-      sut.processOptions(List("basedir:/base/dir", "projectId:myProject"), s => ())
+      sut.processOptions(List("basedir:/base/dir", "projectId:myProject", "excludePackages:myRegex,yourRegex"), s => ())
       sut.options.projectId mustEqual "myProject"
       sut.options.baseDir.getAbsolutePath mustEqual "/base/dir"
+      sut.options.excludePackages mustEqual Array("myRegex".r, "yourRegex".r)
     }
     "report error" in {
       var err = ""

--- a/src/test/scala/reaktor/scct/ScctInstrumentPluginSpec.scala
+++ b/src/test/scala/reaktor/scct/ScctInstrumentPluginSpec.scala
@@ -3,7 +3,6 @@ package reaktor.scct
 import org.specs2.mutable._
 import org.specs2.mock._
 import tools.nsc.Global
-import java.io.File
 
 class ScctInstrumentPluginSpec extends Specification with Mockito {
   val sut = new ScctInstrumentPlugin(smartMock[Global])


### PR DESCRIPTION
New system property provides a comma separated list of regex's for the paths to ignore in coverage.
Files matching these patterns are excluded from the final coverage reports.

```
<scct.excluded.paths.regex>src/main/scala/.*Excluded.*/morepath,other/excluded/path/regex</scct.excluded.paths.regex>
```

I have tested against my own project and it works for me.

Any matching files are dropped entirely from the reports,

However, I have not been able to run any of the tests in the scct package as I keep getting an errors, presumably to do with my runtime env like the one below.

```
test-fail: Scala compiler is probably not finding scala jars (catch-22).
Fix paths in InstrumentationSpec:createSettings.
```
